### PR TITLE
Update title attr in extract-data.xsl

### DIFF
--- a/xsl/extract-data.xsl
+++ b/xsl/extract-data.xsl
@@ -38,7 +38,7 @@
 
   <xsl:template match="/dita | *[contains(@class, ' topic/topic ')]">
     <xsl:variable name="TITLE">
-      <xsl:value-of select="replace(*[contains(@class, ' topic/title ')],'&#xA;', ' ')"/>
+      <xsl:value-of select="normalize-space(replace(*[contains(@class, ' topic/title ')],'&#xA;', ' '))"/>
     </xsl:variable>
     <xsl:variable name="KEYWORDS">
       <xsl:for-each


### PR DESCRIPTION
wrap previous xpath in a normalize-space() function to prevent trailing or leading line breaks from causing issues with generating search previews

These line breaks were causing the build to fail when generating the search results previews for Lunr.